### PR TITLE
Add an AND condition to guarantee only valid node to aggregate

### DIFF
--- a/Dynamic_Programming/673.Number-of-Longest-Increasing-Subsequence/Readme.md
+++ b/Dynamic_Programming/673.Number-of-Longest-Increasing-Subsequence/Readme.md
@@ -6,7 +6,7 @@
 
 ```len[i] = max (len[j]+1) for 0<=j<i && nums[j]<nums[i]```
 
-```num[i] = sum (num[j]) for 0<=j<i && len[j]+1=len[i]```
+```num[i] = sum (num[j]) for 0<=j<i && len[j]+1=len[i] && nums[j]<nums[i]```
 
 
 [Leetcode Link](https://leetcode.com/problems/number-of-longest-increasing-subsequence)


### PR DESCRIPTION
It's gonna fail the test case as below if without checking `nums[j] < nums[i]`
```
[1,2,4,3,5,4,7,2]
exp: 3
act: 4
```