### PR TITLE
fix: 更新 right+1 边界时，未考虑是否会破坏原 right +1；

### DIFF
--- a/Segment_Tree/699.Falling-Squares/699.Falling-Squares_Heap_v1.cpp
+++ b/Segment_Tree/699.Falling-Squares/699.Falling-Squares_Heap_v1.cpp
@@ -1,44 +1,42 @@
 class Solution {
 public:
-    vector<int> fallingSquares(vector<pair<int, int>>& positions) 
-    {
-        map<int,int>Map;
-        
-        Map[0]=0;
-        Map[INT_MAX]=0;
-        
-        vector<int>results;
-        int cur=0;
-        
-        for (auto p:positions)
-        {
-            int left=p.first;
-            int right=p.first+p.second-1;
-            int h=p.second;
-            int maxH=0;
-            
+    vector<int> fallingSquares(vector <vector<int>> &positions) {
+        map<int, int> Map;
+
+        Map[0] = 0;
+        Map[INT_MAX] = 0;
+
+        vector<int> results;
+        int cur = 0;
+
+        for (auto p: positions) {
+            int left = p[0];
+            int right = p[0] + p[1] - 1;
+            int h = p[1];
+            int maxH = 0;
+
             auto ptri = Map.lower_bound(left);
             auto ptrj = Map.upper_bound(right);
-            
-            int temp = prev(ptrj,1)->second;
-            
-            auto ptr = ptri->first==left? ptri:prev(ptri,1);
-            while (ptr!=ptrj)            
-            {
-                maxH=max(maxH, ptr->second);
-                ptr = next(ptr,1);
+
+            int temp = prev(ptrj, 1)->second;
+
+            auto ptr = ptri->first == left ? ptri : prev(ptri, 1);
+            while (ptr != ptrj) {
+                maxH = max(maxH, ptr->second);
+                ptr = next(ptr, 1);
             }
-            if (ptri!=ptrj)
-                Map.erase(ptri,ptrj);
-                            
-            Map[left] = maxH+h;
-            Map[right+1] = temp;            
-            cur = max(cur, maxH+h);
-            
-            results.push_back(cur);    
+            if (ptri != ptrj)
+                Map.erase(ptri, ptrj);
+
+            Map[left] = maxH + h;
+            if (right + 1 < ptrj->first)
+                Map[right + 1] = temp;
+            cur = max(cur, maxH + h);
+
+            results.push_back(cur);
         }
-        
+
         return results;
-        
+
     }
 };

--- a/Segment_Tree/699.Falling-Squares/699.Falling-Squares_Heap_v2.cpp
+++ b/Segment_Tree/699.Falling-Squares/699.Falling-Squares_Heap_v2.cpp
@@ -1,39 +1,37 @@
 class Solution {
 public:
-    vector<int> fallingSquares(vector<pair<int, int>>& positions) 
-    {
-        map<int,int>Map;
-        Map[0]=0;
-        Map[INT_MAX]=0;
-        int cur=0;
-        vector<int>results;
-        
-        for (int i=0; i<positions.size(); i++)
-        {
-            int left=positions[i].first;            
-            int len=positions[i].second;
-            int right=left+len-1;
-            
+    vector<int> fallingSquares(vector <vector<int>> &positions) {
+        map<int, int> Map;
+        Map[0] = 0;
+        Map[INT_MAX] = 0;
+        int cur = 0;
+        vector<int> results;
+
+        for (int i = 0; i < positions.size(); i++) {
+            int left = positions[i][0];
+            int len = positions[i][1];
+            int right = left + len - 1;
+
             auto pos1 = Map.lower_bound(left);
-            
-            int Hmax=0;
-            auto pos=pos1;
-            if (pos->first!=left) pos=prev(pos,1);
-            while (pos->first <= right)            
-            {
+
+            int Hmax = 0;
+            auto pos = pos1;
+            if (pos->first != left) pos = prev(pos, 1);
+            while (pos->first <= right) {
                 Hmax = max(Hmax, pos->second);
-                pos = next(pos,1);
+                pos = next(pos, 1);
             }
-            int rightHeight = prev(pos,1)->second;
-            
-            Map.erase(pos1,pos);
-            Map[left]=Hmax+len;
-            Map[right+1]=rightHeight;                
-            
-            cur = max(cur, Hmax+len);
+            int rightHeight = prev(pos, 1)->second;
+
+            Map.erase(pos1, pos);
+            Map[left] = Hmax + len;
+            if (right + 1 < pos->first)
+                Map[right + 1] = rightHeight;
+
+            cur = max(cur, Hmax + len);
             results.push_back(cur);
         }
-        
+
         return results;
     }
 };


### PR DESCRIPTION
## 关联 Issue
https://github.com/wisdompeak/LeetCode/issues/88

## 改动
1. 更新 Map[right + 1] 时，增加边界判断
2. 方法入参对齐 Leetcode，更改为 `vector <vector<int>> &positions`
3. 代码格式化：操作符间等加空格符，去除空白行中的空格符；
