### PR TITLE
Refactor: Change loop variable type from int to char for clarity

### DIFF
--- a/DFS/037.Sudoku-Solver/037.Sudoku-Solver.cpp
+++ b/DFS/037.Sudoku-Solver/037.Sudoku-Solver.cpp
@@ -11,7 +11,7 @@ public:
         if (j==9) return DFS(board, i+1, 0);
         if (board[i][j]!='.') return DFS(board, i, j+1);
         
-        for (int k='1'; k<='9'; k++)
+        for (char k='1'; k<='9'; k++)
         {            
             if (!isValid(board, i, j, k)) continue;
             board[i][j]=k;


### PR DESCRIPTION
Updated the loop variable in the DFS function from `int k` to `char k` to improve clarity and maintain consistency with the Sudoku board's data type. 

This change avoids implicit type conversions and ensures that the code directly represents the intended operations on character data ('1' to '9').