### PR TITLE
Fix integer overflow in LC260. Single Number III

### DIFF
--- a/Bit_Manipulation/260.Single-Number-III/260.Single-Number-III.cpp
+++ b/Bit_Manipulation/260.Single-Number-III/260.Single-Number-III.cpp
@@ -2,9 +2,9 @@ class Solution {
 public:
     vector<int> singleNumber(vector<int>& nums) 
     {
-        int s = 0;
+        long long s = 0;
         for (auto n:nums) s = s^n;  // i.e. a^b
-        int t = s^(s&(s-1)); // only keep the rightmost set bit
+        long long t = s^(s&(s-1)); // only keep the rightmost set bit
         int a = 0, b = 0;
         for (auto n:nums)
         {


### PR DESCRIPTION
- Changed `int` to `long long` for variable `s` to prevent overflow when handling `INT_MIN` (`-2147483648`).
- Updated `t` to use `long long` to ensure correctness in bit manipulation.
- Fixes issue with new test case: `nums = [1,1,0,-2147483648]`, where `int` overflowed due to `s & (s-1)`.