### PR TITLE
upper bound of TotalNumbersBeginWith() is (prefix * exp + exp - 1)

### DIFF
--- a/Others/440.K-th-Smallest-in-Lexicographical-Order/440.K-th-Smallest-in-Lexicographical-Order.cpp
+++ b/Others/440.K-th-Smallest-in-Lexicographical-Order/440.K-th-Smallest-in-Lexicographical-Order.cpp
@@ -33,7 +33,7 @@ public:
         while (1)
         {
             long lower = prefix * exp;
-            long upper = prefix * exp + exp + 1;
+            long upper = prefix * exp + exp - 1;
             if (lower > n) break;
             if (lower <= n && upper >= n)
             {


### PR DESCRIPTION
In problem 440.K-th-Smallest-in-Lexicographical-Order.cpp

Function TotalNumbersBeginWith(), the upper bound is miswritten to 
> prefix * exp + exp **+** 1

Which is incorrect, for example: 
In the first iteration of the calculation where prefix is 1 and exp is 10, the upper bound of the total number starts with prefix "1" will become 1 * 10 + 10 + 1 = 21 rather than the correct value 1 * 10 + 10 - 1 = 19.
Hence, the correct value assignment should be

> prefix * exp + exp **-** 1