### PR TITLE
Fix typo: s.mgth() -> s.size() in 3234.Count-the-Number-of-Substrings-With-Dominant-Ones

### DIFF
--- a/Two_Pointers/3234.Count-the-Number-of-Substrings-With-Dominant-Ones/3234.Count-the-Number-of-Substrings-With-Dominant-Ones.cpp
+++ b/Two_Pointers/3234.Count-the-Number-of-Substrings-With-Dominant-Ones/3234.Count-the-Number-of-Substrings-With-Dominant-Ones.cpp
@@ -21,7 +21,7 @@ public:
                 if (right[j-1] + have >= count*count)
                 {
                     int extra = right[j-1] - max(0, count*count-have);
-                    ret += max(extra+1, 0);
+                    ret += extra+1;
                 }
 
                 count -= (s[i]=='0');
@@ -39,7 +39,7 @@ public:
 
     std::vector<int> computeRightArray(const std::string& s) 
     {
-        int n = s.mgth();
+        int n = s.size();
         std::vector<int> right(n, 0);
 
         for (int i = n-2; i >=0; i--) {


### PR DESCRIPTION
Fix typo: s.mgth() -> s.size() in 3234.Count-the-Number-of-Substrings-With-Dominant-Ones

Also, we don't need max() on line 24: 
```cpp
ret += extra+1;
```

because the if statement: 
```cpp
if (right[j-1] + have >= count*count)
```
already ensures the variable extra is non-negative.